### PR TITLE
add timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ gargs_race
 binaries
 ssshtest
 gargs
+*.directory

--- a/main.go
+++ b/main.go
@@ -14,9 +14,9 @@ import (
 	"time"
 
 	"github.com/alexflint/go-arg"
-	"github.com/brentp/gargs/process"
 	"github.com/fatih/color"
 	isatty "github.com/mattn/go-isatty"
+	"github.com/shenwei356/gargs/process"
 	"github.com/valyala/fasttemplate"
 )
 

--- a/main.go
+++ b/main.go
@@ -112,7 +112,7 @@ func fillTmplMap(toks []string, line string) map[string]interface{} {
 
 func getScanner() *bufio.Scanner {
 	scanner := bufio.NewScanner(os.Stdin)
-	scanner.Buffer(make([]byte, 0, 16384), 5e9)
+	scanner.Buffer(make([]byte, 0, 16384), 2147483647) // max value of int32, for 32-bit compatibility
 	return scanner
 }
 

--- a/main.go
+++ b/main.go
@@ -14,9 +14,9 @@ import (
 	"time"
 
 	"github.com/alexflint/go-arg"
+	"github.com/brentp/gargs/process"
 	"github.com/fatih/color"
 	isatty "github.com/mattn/go-isatty"
-	"github.com/shenwei356/gargs/process"
 	"github.com/valyala/fasttemplate"
 )
 

--- a/process/process.go
+++ b/process/process.go
@@ -133,7 +133,7 @@ func Run(command string, opts *Options, env ...string) *Command {
 	var c *Command
 	var retries int
 	if opts == nil {
-		c = oneRun(command, nil, opts.Timeout, env)
+		c = oneRun(command, nil, 0, env)
 	} else {
 		c = oneRun(command, opts.CallBack, opts.Timeout, env)
 		retries = opts.Retries

--- a/process/process.go
+++ b/process/process.go
@@ -231,12 +231,11 @@ func oneRun(command string, callback CallBack, timeout time.Duration, env []stri
 
 	// handle output
 	var res []byte
-	var err2 error
 
 	if timeout > 0 {
 		// known shortcoming: this goroutine will remains even after timeout!
-		// this will cause data race.
 		go func() { // goroutine #P
+			var err2 error
 			// Peek is blocked method, it waits command even after timeout!!
 			res, err2 = bpipe.Peek(BufferSize)
 			chErr <- err2

--- a/tests/functional-test.sh
+++ b/tests/functional-test.sh
@@ -151,3 +151,10 @@ assert_exit_code 0
 assert_equal $(cat $STDOUT_FILE | wc -l) 4
 assert_in_stdout "7 8 9"
 assert_equal $(grep -c "^10$" $STDOUT_FILE) 1
+
+# time out
+fn_check_timeout() {
+	seq 1 | ./gargs_race -t 1 "sleep 5; echo asdf"
+}
+run fn_check_timeout
+assert_no_stdout

--- a/tests/functional-test.sh
+++ b/tests/functional-test.sh
@@ -154,7 +154,18 @@ assert_equal $(grep -c "^10$" $STDOUT_FILE) 1
 
 # time out
 fn_check_timeout() {
-	seq 1 | ./gargs_race -t 1 "sleep 5; echo asdf"
+	seq 1 10 | ./gargs_race -t 1 "sleep 2; echo asdf"
 }
-run fn_check_timeout
+run time_out fn_check_timeout
 assert_no_stdout
+assert_in_stderr "time out"
+assert_equal $(cat $STDERR_FILE | grep "time out" | wc -l) 10
+
+# time out 2, timeout > running time
+fn_check_timeout2() {
+	seq 1 10 | ./gargs_race -t 2 "sleep 1; echo asdf"
+}
+run time_out2 fn_check_timeout2
+assert_no_stderr
+assert_in_stdout "asdf"
+assert_equal $(cat $STDOUT_FILE | grep "asdf" | wc -l) 10


### PR DESCRIPTION
see newest version: https://github.com/brentp/gargs/pull/6#issuecomment-270841382

------

A timeout option added (#5) :

```
  --timeout TIMEOUT, -t TIMEOUT
                         timeout of a command. Unit is second and 0 with no timeout (default is 0).
```

Example:

No timeout:

```
$ time echo msg | ./gargs  'sleep 2; echo {}' 
msg

real    0m2.010s
user    0m0.003s
sys     0m0.008s
```

With timeout

```
$ time echo msg | ./gargs  'sleep 2; echo {}' -t 1
ERROR with command: Command('sleep 2; echo msg', stdout: '', exit-code: -1, error: signal: killed, run-time: 2.003461041s)

real    0m2.008s
user    0m0.006s
sys     0m0.002s
```
But the run-time is longer than the actual running time.
